### PR TITLE
add radix-job-type label to secrets and services

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,7 +20,7 @@
                 "RADIX_ENVIRONMENT":"qa",
                 "RADIX_APP":"radix-job-demo",
                 "RADIX_JOB_SCHEDULERS_PER_ENVIRONMENT_HISTORY_LIMIT": "2",
-                "RADIX_DEPLOYMENT": "qa-ptjfz-fxgan1bc",
+                "RADIX_DEPLOYMENT": "qa-0a7jk-fb6aqjib",
                 "RADIX_COMPONENT": "compute",
                 "RADIX_PORTS": "8081"
             }

--- a/api/handlers/job/secrets.go
+++ b/api/handlers/job/secrets.go
@@ -46,6 +46,7 @@ func buildPayloadSecretSpec(secretName, payload, jobName, appName, componentName
 			Labels: map[string]string{
 				kube.RadixAppLabel:       appName,
 				kube.RadixComponentLabel: componentName,
+				kube.RadixJobTypeLabel:   kube.RadixJobTypeJobSchedule,
 				kube.RadixJobNameLabel:   jobName,
 			},
 		},

--- a/api/handlers/job/services.go
+++ b/api/handlers/job/services.go
@@ -42,6 +42,7 @@ func buildServiceSpec(serviceName, jobName, componentName, appName string, compo
 			Labels: map[string]string{
 				kube.RadixAppLabel:       appName,
 				kube.RadixComponentLabel: componentName,
+				kube.RadixJobTypeLabel:   kube.RadixJobTypeJobSchedule,
 				kube.RadixJobNameLabel:   jobName,
 			},
 		},


### PR DESCRIPTION
- Labels will be used in radix-operator to identify if a secret or service is related to a job created by job-scheduler. Secrets and services will be deleted if they are identified to belong to a job, and that job is no longer in the jobs section in RD