### PR TITLE
change restart policy

### DIFF
--- a/api/handlers/job/jobs.go
+++ b/api/handlers/job/jobs.go
@@ -90,7 +90,7 @@ func buildJobSpec(jobName string, rd *radixv1.RadixDeployment, radixJobComponent
 					Containers:      containers,
 					Volumes:         volumes,
 					SecurityContext: podSecurityContext,
-					RestartPolicy:   corev1.RestartPolicyOnFailure, //TODO: decide what to do with failed job
+					RestartPolicy:   corev1.RestartPolicyNever, //TODO: decide what to do with failed job
 				},
 			},
 		},


### PR DESCRIPTION
The RestartPolicyOnFailure caused the pod (and also logs) to be deleted on failure.
RestartPolicyNever keeps the pod even on failure so users (or we) can examine logs